### PR TITLE
add bogas04 to contributors, links of commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ Thanks goes to these wonderful people ([emoji key](https://github.com/kentcdodds
 
 Contributor | Contributions
 :---: | :---:
-[![Kent C. Dodds](https://avatars1.githubusercontent.com/u/1500684?s=130)<br />Kent C. Dodds](http://kentcdodds.com) | 📖
+[![Kent C. Dodds](https://avatars1.githubusercontent.com/u/1500684?s=130)<br />Kent C. Dodds](http://kentcdodds.com) | [📖](https://github.com/kentcdodds/all-contributors/commits?author=kentcdodds)
+[![Divjot Singh](https://avatars1.githubusercontent.com/u/6177621?s=130)<br />Divjot Singh](http://bogas04.github.io) | [📖](https://github.com/kentcdodds/all-contributors/commits?author=bogas04)
 
 This project follows the [all-contributors](https://github.com/kentcdodds/all-contributors) specification.
 Contributions of any kind welcome!


### PR DESCRIPTION
As per specification link to commits should be added for the code emoji.