### PR TITLE
Replace question mark with help desk emoji

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,14 @@ Projects should consider the following optional items as part of their commitmen
 
 ## Emoji key
 
-Emoji | Represents | Links to
-:---: | --- | ---
+Emoji | Represents | Links to | Comment
+:---: | --- | --- | ---
 💻 | Code | `https://github.com/${ownerName}/${repoName}/commits?author=${username}`
 🔌 | Plugin/utility libraries | the repo home
 🔧 | Tools | the repo home
 📖 | Documentation | `https://github.com/${ownerName}/${repoName}/commits?author=${username}`, Wiki, or other source of documentation
 🌍 | Translation | the translated content
-❓ | Answering Questions (in Issues, Stack Overflow, Gitter, Slack, etc.)
+💁 | Answering Questions (in Issues, Stack Overflow, Gitter, Slack, etc.) | | previously: ❓
 ⚠️ | Tests | `https://github.com/${ownerName}/${repoName}/commits?author=${username}`
 🐛 | Bug reports | `https://github.com/${ownerName}/${repoName}/issues?q=author%3A${username}`
 💡 | Examples | the examples
@@ -62,10 +62,10 @@ Emoji | Represents | Links to
 
 Thanks goes to these wonderful people ([emoji key](https://github.com/kentcdodds/all-contributors#emoji-key)):
 
-| [![Kent C. Dodds](https://avatars1.githubusercontent.com/u/1500684?s=100)<br /><sub>Kent C. Dodds</sub>](http://kentcdodds.com)<br />[📖](https://github.com/kentcdodds/all-contributors/commits?author=kentcdodds) 👀 ❓ | [![Divjot Singh](https://avatars1.githubusercontent.com/u/6177621?s=100)<br /><sub>Divjot Singh</sub>](http://bogas04.github.io)<br />[📖](https://github.com/kentcdodds/all-contributors/commits?author=bogas04) 👀 | [![Ben Briggs](https://avatars1.githubusercontent.com/u/1282980?v=3&s=100)<br /><sub>Ben Briggs</sub>](http://beneb.info)<br />[📖](https://github.com/kentcdodds/all-contributors/commits?author=ben-eb) 👀 | [![James Monger](https://avatars1.githubusercontent.com/u/2037007?v=3&s=100)<br /><sub>James Monger</sub>](http://github.com/Jameskmonger)<br />[📖](https://github.com/kentcdodds/all-contributors/commits?author=Jameskmonger) | [![Jeroen Engels](https://avatars.githubusercontent.com/u/3869412?v=3&s=100)<br /><sub>Jeroen Engels</sub>](https://github.com/jfmengels)<br />[📖](https://github.com/kentcdodds/all-contributors/commits?author=jfmengels) [🔧](https://www.npmjs.com/package/all-contributors-cli) 👀 | [![Chris Simpkins](https://avatars0.githubusercontent.com/u/4249591?v=3&s=100)<br /><sub>Chris Simpkins</sub>](http://github.com/chrissimpkins)<br />[📖](https://github.com/kentcdodds/all-contributors/commits?author=chrissimpkins) 👀 | [![Frederic Hemberger](https://avatars0.githubusercontent.com/u/153481?v=3&s=100)<br /><sub>F. Hemberger</sub>](http://github.com/fhemberger)<br />[📖](https://github.com/kentcdodds/all-contributors/commits?author=fhemberger) | 
+| [![Kent C. Dodds](https://avatars1.githubusercontent.com/u/1500684?s=100)<br /><sub>Kent C. Dodds</sub>](http://kentcdodds.com)<br />[📖](https://github.com/kentcdodds/all-contributors/commits?author=kentcdodds) 👀 💁 | [![Divjot Singh](https://avatars1.githubusercontent.com/u/6177621?s=100)<br /><sub>Divjot Singh</sub>](http://bogas04.github.io)<br />[📖](https://github.com/kentcdodds/all-contributors/commits?author=bogas04) 👀 | [![Ben Briggs](https://avatars1.githubusercontent.com/u/1282980?v=3&s=100)<br /><sub>Ben Briggs</sub>](http://beneb.info)<br />[📖](https://github.com/kentcdodds/all-contributors/commits?author=ben-eb) 👀 | [![James Monger](https://avatars1.githubusercontent.com/u/2037007?v=3&s=100)<br /><sub>James Monger</sub>](http://github.com/Jameskmonger)<br />[📖](https://github.com/kentcdodds/all-contributors/commits?author=Jameskmonger) | [![Jeroen Engels](https://avatars.githubusercontent.com/u/3869412?v=3&s=100)<br /><sub>Jeroen Engels</sub>](https://github.com/jfmengels)<br />[📖](https://github.com/kentcdodds/all-contributors/commits?author=jfmengels) [🔧](https://www.npmjs.com/package/all-contributors-cli) 👀 | [![Chris Simpkins](https://avatars0.githubusercontent.com/u/4249591?v=3&s=100)<br /><sub>Chris Simpkins</sub>](http://github.com/chrissimpkins)<br />[📖](https://github.com/kentcdodds/all-contributors/commits?author=chrissimpkins) 👀 | [![Frederic Hemberger](https://avatars0.githubusercontent.com/u/153481?v=3&s=100)<br /><sub>F. Hemberger</sub>](http://github.com/fhemberger)<br />[📖](https://github.com/kentcdodds/all-contributors/commits?author=fhemberger) |
 | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
 
-| [![Daniel Kraft](https://avatars1.githubusercontent.com/u/3982200?v=3&s=100)<br /><sub>Daniel Kraft</sub>](http://github.com/frigginglorious)<br />[📖](https://github.com/kentcdodds/all-contributors/commits?author=frigginglorious) | 
+| [![Daniel Kraft](https://avatars1.githubusercontent.com/u/3982200?v=3&s=100)<br /><sub>Daniel Kraft</sub>](http://github.com/frigginglorious)<br />[📖](https://github.com/kentcdodds/all-contributors/commits?author=frigginglorious) |
 | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
 
 This project follows the [all-contributors](https://github.com/kentcdodds/all-contributors) specification.


### PR DESCRIPTION
Updates the question-mark usage on the contributor listing itself. Keep record of old usage for people implementing the prior version. As it is the only one I left that in a separate column at the end, but we might want to keep a general record around elsewhere per version maybe? I just added it so we don't forget it and people can easily find its meaning still.

This is what it looks like rendered: https://gist.github.com/ligthyear/a3147ff03cbf0a891367

Fixes #35