### PR TITLE
feat(script): add postinstall script

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,9 @@
+if (!process.env.CI) {
+  var message = '\n\n\n*******\n\nIt looks like you tried to install all-contributors into your project. ' +
+    'This module is simply a specification and doesn\'t actually do anything.\nIf you meant to install the CLI, please ' +
+    'uninstall this module first (npm uninstall all-contributors) and install `all-contributors-cli`.\n\n*******\n\n\n\n'
+
+  console.error(message)
+  process.exitCode = 1
+}
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,8 @@
 {
   "name": "all-contributors",
+  "description": "✨ Recognize all contributors, not just the ones who push code ✨",
   "version": "0.0.0-semantically-released",
+  "bin": "index.js",
   "main": "index.js",
   "repository": "git@github.com:kentcdodds/all-contributors.git",
   "author": "Kent C. Dodds <kent@doddsfamily.us> (http://kentcdodds.com/)",
@@ -10,6 +12,7 @@
   },
   "scripts": {
     "test": "echo \"no tests exist yet... Any ideas?\"",
+    "postinstall": "node index.js",
     "add-contributor": "all-contributors add",
     "generate-contributors": "all-contributors generate",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"


### PR DESCRIPTION
So people don't mistakenly install this package. We have it on npm so we
can keep it versioned nicely, but we don't want people actually
installing it.

Could I get a review/merge on this?