### PR TITLE
Introduce CHANGELOG to keep track of changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+hangelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic
+Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [2.1.0] - 2017-08-03
+### Added
+- Ideas and planning contribution type.
+
+## [2.0.0] - 2017-01-22
+### Changed
+- Answering questions changed to non-gender-specific emoji.
+
+[Unreleased]: https://github.com/kentcdodds/all-contributors/compare/v2.1.0...HEAD
+[2.1.0]: https://github.com/kentcdodds/all-contributors/compare/v2.0.0...v2.1.0
+[2.0.0]: https://github.com/kentcdodds/all-contributors/compare/v1.1.1...v2.0.0


### PR DESCRIPTION
Following the [Keep a Changelog format](http://keepachangelog.com/en/1.0.0/), introduce a CHANGELOG to keep track of changes to the project. I tried to capture what had changed from an All Contributors prospective that needed to be communicated to end users. I only captured the `2.1.0` and `2.0.0` releases, also didn't capture the `Unreleased` changes.

Hope this is useful! Thanks!