### PR TITLE
doc: add redux-subspace to IMPLEMENTATIONS.md

### DIFF
--- a/other/IMPLEMENTATIONS.md
+++ b/other/IMPLEMENTATIONS.md
@@ -23,6 +23,7 @@ list, please [make a pull request](https://github.com/kentcdodds/all-contributor
 - [jmeas/redux-resource](https://github.com/jmeas/redux-resource)
 - [render_async](https://github.com/renderedtext/render_async)
 - [GitPoint](https://github.com/gitpoint/git-point)
+- [ioof-holdings/redux-subspace](https://github.com/ioof-holdings/redux-subspace)
 
 **Note**: There are likely many projects not listed here. You'll probably be able to find more with this
 [github search](https://github.com/search?utf8=%E2%9C%93&q=.all-contributorsrc+in%3Apath&type=Code&ref=searchresults)


### PR DESCRIPTION
Added [ioof-holdings/redux-subspace](https://github.com/ioof-holdings/redux-subspace#contributors) to the implementations docs.